### PR TITLE
 Corrected rmse syntax 

### DIFF
--- a/src/logic/data_analysis.py
+++ b/src/logic/data_analysis.py
@@ -1,5 +1,5 @@
 import numpy as np
-from sklearn.metrics import mean_squared_error, mean_absolute_error, r2_score
+from sklearn.metrics import mean_squared_error, mean_absolute_error, r2_score, root_mean_squared_error
 from sklearn.model_selection import train_test_split
 from .baseline_model import prepare_data, train_baseline_model
 
@@ -30,7 +30,7 @@ def evaluate_model(stock_data, feature_days=5, threshold_percentage=0.01):
     mse = mean_squared_error(y_test, y_pred)
     mae = mean_absolute_error(y_test, y_pred)
     r_squared = r2_score(y_test, y_pred)
-    rmse = mean_squared_error(y_test, y_pred, squared=False)
+    rmse = root_mean_squared_error(y_test, y_pred)
 
 
     percentage_diff = np.abs((y_pred - y_test) / y_test)


### PR DESCRIPTION
Previous method of getting the rmse is going to be discontinued in sklearn 1.6 so updated the function to what will be standard.